### PR TITLE
feat: component StackBlitz added

### DIFF
--- a/packages/media-content/README.md
+++ b/packages/media-content/README.md
@@ -14,6 +14,7 @@ A collection of typed Svelte components to easily embed media contents in your p
 - CodeSandbox
 - Facebook
 - SlideShare
+- StackBlitz
 - Tweet
 - Vimeo
 - YouTube
@@ -177,6 +178,35 @@ pnpm dev
    user="DataReportal"
    title="Digital 2020 Global Digital Overview (January 2020) v01"
 />
+```
+
+### StackBlitz
+
+**DEFAULT SETTINGS**
+
+```html
+<script>
+ import { StackBlitz } from '@sveltinio/media-content';
+</script>
+
+<StackBlitz id="vitejs-vite-z3ukcq" />
+```
+
+**WITH CUSTOM SETTINGS**
+
+```html
+<script>
+ import { StackBlitz } from '@sveltinio/media-content';
+ import { IStackBlitzSettings } from '@sveltinio/media-content/types';
+
+ // https://developer.stackblitz.com/docs/platform/embedding/
+ const sbSettings: IStackBlitzSettings = {
+    ctl: true,
+    devtoolsheight: 400
+ }
+</script>
+
+<StackBlitz id="vitejs-vite-z3ukcq" settings={sbSettings} />
 ```
 
 ### Twitter

--- a/packages/media-content/src/lib/__tests__/StackBlitz.spec.ts
+++ b/packages/media-content/src/lib/__tests__/StackBlitz.spec.ts
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { StackBlitz } from '..';
+import { stackblitzSample, stackblitzSettings } from './__fixtures__/data.test.js';
+
+describe('StackBlitz', () => {
+	it('should be in the document', async () => {
+		const { container } = render(StackBlitz, {
+			props: {
+				id: stackblitzSample.id,
+				title: stackblitzSample.title
+			}
+		});
+		expect(container).toBeInTheDocument();
+	});
+
+	it('should contain the iframe', async () => {
+		const { getByTestId } = render(StackBlitz, {
+			props: {
+				id: stackblitzSample.id,
+				title: stackblitzSample.title
+			}
+		});
+		expect(getByTestId('wrapper')).toContainElement(getByTestId('iframe'));
+	});
+
+	it('should have the iframe url defined', async () => {
+		const { getByTestId } = render(StackBlitz, {
+			props: {
+				id: stackblitzSample.id,
+				title: stackblitzSample.title
+			}
+		});
+		const iframe = getByTestId('iframe');
+		expect(iframe['src']).toBeDefined();
+	});
+
+	it('should have a valid url to a StackBlitz project', async () => {
+		const { getByTestId } = render(StackBlitz, {
+			props: {
+				id: stackblitzSample.id,
+				title: stackblitzSample.title
+			}
+		});
+		const iframe = getByTestId('iframe');
+		console.log(iframe);
+		expect(iframe['src']).toBe('https://stackblitz.com/edit/vitejs-vite-z3ukcq');
+	});
+
+	it('should have an accessible description (title)', async () => {
+		const { getByTestId } = render(StackBlitz, {
+			props: {
+				id: stackblitzSample.id,
+				title: stackblitzSample.title
+			}
+		});
+		expect(getByTestId('iframe')).toHaveAccessibleDescription();
+	});
+});
+
+describe('StackBlitz - options', () => {
+	it('should have a props defined for iframe url', async () => {
+		const { getByTestId } = render(StackBlitz, {
+			props: {
+				id: stackblitzSample.id,
+				title: stackblitzSample.title,
+				settings: stackblitzSettings
+			}
+		});
+		const iframe = getByTestId('iframe');
+		expect(iframe['src']).toBe(
+			'https://stackblitz.com/edit/vitejs-vite-z3ukcq?file=svelte.config.js&embed=1&theme=light&ctl=1&devtoolsheight=200'
+		);
+	});
+});

--- a/packages/media-content/src/lib/__tests__/__fixtures__/data.test.js.ts
+++ b/packages/media-content/src/lib/__tests__/__fixtures__/data.test.js.ts
@@ -3,6 +3,7 @@ import type {
 	ICodeSandboxSettings,
 	IFacebookSettings,
 	IFacebookVideoSettings,
+	IStackBlitzSettings,
 	ITweetSettings,
 	IVimeoSettings,
 	IYouTubeSettings
@@ -60,6 +61,20 @@ export const slideShareSample: Record<string, string> = {
 	id: 'exvMftSyV7yRQR',
 	title: 'Digital 2020 Global Digital Overview (January 2020) v01',
 	user: 'DataReportal'
+};
+
+// STACKBLITZ
+export const stackblitzSample: Record<string, string> = {
+	id: 'vitejs-vite-z3ukcq',
+	title: 'Sample Vite + Svelte + TypeScript project'
+};
+
+export const stackblitzSettings: IStackBlitzSettings = {
+	file: 'svelte.config.js',
+	embed: true,
+	theme: 'light',
+	ctl: true,
+	devtoolsheight: 200
 };
 
 // TWITTER

--- a/packages/media-content/src/lib/components/StackBlitz.svelte
+++ b/packages/media-content/src/lib/components/StackBlitz.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import type { IStackBlitzSettings } from '../types';
+	import { makeSettingsString, toKebabCase } from '../utils';
+
+	/** The id for the project to embed. */
+	export let id: string;
+	export let title = '';
+	/**
+	 * These attributes control which project is embedded and how it looks and behaves.
+	 *
+	 * https://developer.stackblitz.com/docs/platform/embedding/
+	 */
+	export let settings: IStackBlitzSettings = {};
+
+	function matchersCallback(key: string, value: string): string {
+		switch (typeof value) {
+			case 'boolean':
+				return `${key}=${Number(value)}`;
+			case 'number':
+				return `${key}=${String(value)}`;
+			default:
+				// default behaviour
+				return `${toKebabCase(key)}=${value}`;
+		}
+	}
+
+	const baseURL = `https://stackblitz.com/edit/${id}`;
+	const settingsString = makeSettingsString<IStackBlitzSettings>(settings, matchersCallback);
+	const iframeURL = settingsString != '' ? baseURL.concat(`?${settingsString}`) : baseURL;
+</script>
+
+<div data-testid="wrapper" id="stackblitz-container-{id}" class="stackblitz-video-container">
+	<iframe
+		data-testid="iframe"
+		id="frame-{id}"
+		class="frame"
+		src={iframeURL}
+		frameborder="0"
+		allowfullscreen
+		allow-same-origin
+		{title}
+	/>
+</div>
+
+<style>
+	.stackblitz-video-container {
+		position: relative;
+		width: 100%;
+		padding-bottom: calc(var(--aspect-ratio, 0.5625) * 100%);
+		height: 0;
+	}
+
+	.frame {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		border: 0;
+		border-radius: 4px;
+	}
+</style>

--- a/packages/media-content/src/lib/index.ts
+++ b/packages/media-content/src/lib/index.ts
@@ -2,8 +2,9 @@ import CodePen from './components/CodePen.svelte';
 import CodeSandbox from './components/CodeSandbox.svelte';
 import Facebook from './components/Facebook.svelte';
 import SlideShare from './components/SlideShare.svelte';
+import StackBlitz from './components/StackBlitz.svelte';
 import Tweet from './components/Tweet.svelte';
 import Vimeo from './components/Vimeo.svelte';
 import YouTube from './components/YouTube.svelte';
 
-export { CodePen, CodeSandbox, Facebook, SlideShare, Tweet, Vimeo, YouTube };
+export { CodePen, CodeSandbox, Facebook, SlideShare, StackBlitz, Tweet, Vimeo, YouTube };

--- a/packages/media-content/src/lib/types.ts
+++ b/packages/media-content/src/lib/types.ts
@@ -188,6 +188,39 @@ export interface IFacebookVideoSettings extends IFacebookSettings {
 	showCaptions?: boolean;
 }
 
+// https://developer.stackblitz.com/docs/platform/embedding/
+export interface IStackBlitzSettings {
+	/** The default file to have open in the editor. */
+	file?: string;
+	/** Force embed view regardless of screen size. */
+	embed?: boolean;
+	/** Hide file explorer pane in embed view. */
+	hideExplorer?: boolean;
+	/** Hide the browser navigation UI. */
+	hideNavigation?: boolean;
+	/** Require user to 'click to load' the embed. */
+	ctl?: boolean;
+	/**
+	 * Which view to open by default.
+	 *
+	 * Supported values are editor or preview.
+	 */
+	view?: string;
+	/** Hide the debugging console in the editor preview. */
+	hidedevtools?: boolean;
+	/** Set the height of the debugging console in the editor preview. */
+	devtoolsheight?: number;
+	/** The initial URL path (URI encoded) the preview should open. */
+	initialpath?: string;
+	/**
+	 * Which theme to show for the embed.
+	 *
+	 * Supported values are dark or light.
+	 * The default value is dark.
+	 */
+	theme?: string;
+}
+
 // https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference
 export interface ITweetSettings {
 	/**

--- a/packages/media-content/src/routes/index.svelte
+++ b/packages/media-content/src/routes/index.svelte
@@ -1,29 +1,40 @@
 <script lang="ts">
-	import { YouTube, Tweet, CodeSandbox, CodePen, Vimeo, SlideShare, Facebook } from '../lib';
+	import {
+		CodePen,
+		CodeSandbox,
+		Facebook,
+		SlideShare,
+		StackBlitz,
+		Tweet,
+		Vimeo,
+		YouTube
+	} from '../lib';
 
 	import {
-		tweetSampleOneId,
-		tweetSampleTwoId,
-		youtubeSampleOne,
-		youtubeSampleTwo,
-		youtubeSampleVideoSettings,
-		youtubeSamplePlayList,
-		youtubeSamplePlaylistSettings,
-		codeSandboxSampleID,
 		codepenSampleOne,
 		codepenSampleTwo,
-		vimeoSample,
-		slideShareSample,
+		codepenSettings,
+		codeSandboxSampleID,
+		codesandboxSettings,
 		facebookSamplePostTwo,
 		facebookSampleVideoTwo,
 		facebookSampleVideoOne,
 		facebookSamplePostOne,
-		tweetSettings,
-		vimeoSettings,
-		codesandboxSettings,
-		codepenSettings,
 		facebookPostSettings,
-		facebookVideoSettings
+		facebookVideoSettings,
+		slideShareSample,
+		stackblitzSample,
+		stackblitzSettings,
+		tweetSampleOneId,
+		tweetSampleTwoId,
+		tweetSettings,
+		vimeoSample,
+		vimeoSettings,
+		youtubeSampleOne,
+		youtubeSampleTwo,
+		youtubeSampleVideoSettings,
+		youtubeSamplePlayList,
+		youtubeSamplePlaylistSettings
 	} from '../lib/__tests__/__fixtures__/data.test.js';
 </script>
 
@@ -82,6 +93,16 @@
 			user={slideShareSample.user}
 			title={slideShareSample.title}
 		/>
+	</section>
+
+	<!-- STACKBLITZ -->
+	<section id="stackblitz-container" class="container">
+		<h3>StackBlitz</h3>
+		<h4>Default options</h4>
+		<StackBlitz id={stackblitzSample.id} />
+		<br />
+		<h4>Custom options</h4>
+		<StackBlitz id={stackblitzSample.id} settings={stackblitzSettings} />
 	</section>
 
 	<!-- TWEET -->


### PR DESCRIPTION
Embed StackBlitz projects:

- new `IStackBlitzSettings` interface added to reflect the available [settings](https://developer.stackblitz.com/docs/platform/embedding/)
- new `StackBlitz.svelte` component added 
- new `StackBlitz.spec.ts` tests suite added
- README updated
- Demo (`src/routes/index.svelte`) page updated