### PR TITLE
svelte as peer dependency

### DIFF
--- a/packages/essentials/package.json
+++ b/packages/essentials/package.json
@@ -104,9 +104,9 @@
 		"dist",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*",
-		"!**/assets",
-		"!**/*.postcss",
-		"!**/dist/components/**/*.md"
+		"!dist/**/*.md",
+		"!dist/**/assets",
+		"!dist/**/*.postcss"
 	],
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/essentials/package.json
+++ b/packages/essentials/package.json
@@ -35,7 +35,9 @@
 		"url": "https://github.com/sveltinio/components-library/issues"
 	},
 	"dependencies": {
-		"@sveltinio/ts-utils": "^0.8.0",
+		"@sveltinio/ts-utils": "^0.8.0"
+	},
+	"peerDependencies": {
 		"svelte": "^3.59.1"
 	},
 	"devDependencies": {
@@ -100,6 +102,8 @@
 	"svelte": "./dist/index.js",
 	"files": [
 		"dist",
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*",
 		"!**/assets",
 		"!**/*.postcss",
 		"!**/dist/components/**/*.md"

--- a/packages/media-content/package.json
+++ b/packages/media-content/package.json
@@ -39,7 +39,9 @@
 		"url": "https://github.com/sveltinio/components-library/issues"
 	},
 	"dependencies": {
-		"@sveltinio/ts-utils": "^0.8.0",
+		"@sveltinio/ts-utils": "^0.8.0"
+	},
+	"peerDependencies": {
 		"svelte": "^3.59.1"
 	},
 	"devDependencies": {

--- a/packages/media-content/package.json
+++ b/packages/media-content/package.json
@@ -92,9 +92,9 @@
 	"svelte": "./dist/index.js",
 	"files": [
 		"dist",
-		"!**/assets",
-		"!**/*.postcss",
-		"!**/dist/components/**/*.md"
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*",
+		"!dist/**/*.md"
 	],
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -77,9 +77,9 @@
 	"svelte": "./dist/index.js",
 	"files": [
 		"dist",
-		"!**/assets",
-		"!**/*.postcss",
-		"!**/dist/components/**/*.md"
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*",
+		"!dist/**/*.md"
 	],
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -29,7 +29,9 @@
 	},
 	"dependencies": {
 		"@sveltinio/ts-utils": "^0.8.0",
-		"schema-dts": "^1.1.2",
+		"schema-dts": "^1.1.2"
+	},
+	"peerDependencies": {
 		"svelte": "^3.59.1"
 	},
 	"devDependencies": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -28,7 +28,9 @@
 	},
 	"dependencies": {
 		"@sveltinio/ts-utils": "^0.8.0",
-		"@types/gtag.js": "^0.0.12",
+		"@types/gtag.js": "^0.0.12"
+	},
+	"peerDependencies": {
 		"svelte": "^3.59.1"
 	},
 	"devDependencies": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -76,9 +76,9 @@
 	"svelte": "./dist/index.js",
 	"files": [
 		"dist",
-		"!**/assets",
-		"!**/*.postcss",
-		"!**/dist/components/**/*.md"
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*",
+		"!dist/**/*.md"
 	],
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -97,9 +97,11 @@
 	"svelte": "./dist/index.js",
 	"files": [
 		"dist",
-		"!**/assets",
-		"!**/*.postcss",
-		"!**/dist/components/**/*.md"
+		"!dist/**/*.test.*",
+		"!dist/**/*.spec.*",
+		"!dist/**/*.md",
+		"!dist/**/assets",
+		"!dist/**/*.postcss"
 	],
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -30,7 +30,9 @@
 	},
 	"dependencies": {
 		"@sveltinio/essentials": "^0.7.8",
-		"@sveltinio/ts-utils": "^0.8.0",
+		"@sveltinio/ts-utils": "^0.8.0"
+	},
+	"peerDependencies": {
 		"svelte": "^3.59.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
- svelte as peer dependency than pure dependency 
- simplify patterns for the `files` field in `package.json`